### PR TITLE
Add type information that TSLint needs for some rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "build": "react-scripts build",
         "test": "react-scripts test",
         "test-once": "CI=true react-scripts test",
-        "lint": "tslint 'src/**/*.{ts,tsx}'",
+        "lint": "tslint --project . 'src/**/*.{ts,tsx}'",
         "eject": "react-scripts eject",
         "prettier": "prettier --write '**/*.{ts,tsx,json,md}' --config .prettierrc"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,23 @@
 {
     "compilerOptions": {
-        "target": "es2015",
+        "typeRoots": ["node_modules/@0x/typescript-typings/types", "node_modules/@types"],
         "module": "esnext",
-        "jsx": "preserve",
-        "strict": true,
-        "esModuleInterop": true,
+        "target": "es5",
+        "lib": ["es6", "dom"],
+        "sourceMap": true,
         "allowJs": true,
-        "skipLibCheck": false,
-        "allowSyntheticDefaultImports": true,
-        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
         "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        "noEmit": true,
-        "lib": ["dom", "dom.iterable", "esnext"]
+        "rootDir": "src",
+        "skipLibCheck": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "suppressImplicitAnyIndexErrors": true,
+        "esModuleInterop": true,
+        "noUnusedLocals": true
     },
-    "include": ["src"]
+    "include": ["src"],
+    "exclude": ["node_modules", "build", "scripts"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,9 @@
         "custom-no-magic-numbers": false,
         "semicolon": [true, "always", "ignore-bound-class-methods"],
         "max-classes-per-file": false,
-        "switch-default": false
+        "switch-default": false,
+        "no-unnecessary-type-assertion": false,
+        "completed-docs": false,
+        "promise-function-async": false
     }
 }


### PR DESCRIPTION
This PR also disables some rules:

- `no-unnecessary-type-assertion` was giving a false positive in [this line](https://github.com/protofire/0x-launchkit-frontend/blob/0851818184af5f716bd86e73f2e083cb95ed7cfb/src/lib/asset_utils.ts#L8). There's an open issue [here](https://github.com/palantir/tslint/issues/3540).
- `completed-docs` is annoying, do we really want docs for exported actions?
- `promise-function-async` adds unnecessary boilerplate, specially when dispatching async actions.